### PR TITLE
Allow opening "add new categories" modal to open when product id_default_category is equal to 0

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/category/category-tree-selector.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/category/category-tree-selector.ts
@@ -71,7 +71,7 @@ export default class CategoryTreeSelector {
   }
 
   public showModal(selectedCategories: Array<Category>, defaultCategoryId: number): void {
-    if (!defaultCategoryId) {
+    if (defaultCategoryId < 0) {
       console.error('Default category id is invalid.');
 
       return;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When a product is created without a default category, it makes it impossible to further assign it categories from the category selector in product edit page. Its default category is 0, and is interpreted as false, preventing the modal from opening.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Set a product id_default_category to 0. Edit the product from BO, and try clicking the button to add new categories to the product. See the modal is opening.
| UI Tests          | NA
| Fixed issue or discussion?     | NA
| Related PRs       |NA
| Sponsor company   | Evolutive
